### PR TITLE
add 0.5s debounce to the search input to improve performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9201,6 +9201,11 @@
         }
       }
     },
+    "loadash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
+      "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg=="
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "loadash": "^1.0.0",
     "react": "^17.0.2",
     "react-css-modules": "^4.7.11",
     "react-dom": "^17.0.2",

--- a/src/Components/Searchbar/SearchBar.js
+++ b/src/Components/Searchbar/SearchBar.js
@@ -5,21 +5,26 @@ import { useSelector, useDispatch } from 'react-redux'
 import { updateSearch } from '../../features/searchSlice';
 import removeAccents from "../../features/removeAccents"
 
+import debounce from 'lodash.debounce';
+
 export default function SearchBar()    {
   const dispatch = useDispatch()
   const [search, setSearch] = useState('')
 
   const handleChange = (e) => {
     const searchInput = removeAccents(e.target.value)
-    setSearch(searchInput);
+    // setSearch(searchInput);
     dispatch(updateSearch(searchInput))
   }
   
+  // delay updating state if user still typing (half second delay)
+  const debounceChange = debounce(handleChange, 500)
+
   return (
     <div className="searchBar">
       <div id="searchBox" className="dmElement corners">
         <div id="searchIcon">< FaSearch/></div>
-        <input id="searchInput" className="dmElement" name="search-query" type="text" placeholder="Search for a country..." onChange={handleChange} />
+        <input id="searchInput" className="dmElement" name="search-query" type="text" placeholder="Search for a country..." onChange={debounceChange} />
       </div>    
     </div>
     )


### PR DESCRIPTION

Piercy87 and I improved the speed a bit by only making a single api call (previously it was re-fetching data on every state change) so it's much quicker already.

So, I've assigned to you three to review and decide whether this is necessary. Currently I find it a tiny bit laggy on adding/deleting the first character or two as this is when there is more data to filter through. This fixes the lag but creates a more consistent delay. Currently it's 0.5s, but we could reduce that. 


- import debounce from loadash 
- add 0.5s debounce to the onChange when updating search state

This basically means that as a user is typing, rather than updating state immediately, running the filter logic and trying to re-render with every character (which can be expensive), it waits until 0.5s to see if the user has stopped typing, and then updates state. 