### PR TITLE
add reset button to search filter bar with functionality

### DIFF
--- a/src/Components/Filter/Filter.js
+++ b/src/Components/Filter/Filter.js
@@ -5,10 +5,9 @@ import { useSelector, useDispatch } from 'react-redux'
 import { updateFilter } from '../../features/filtersSlice';
 
 export default function Filter(props) {
-
+  const filters = useSelector(state => state.filters);
   const dispatch = useDispatch()
   const [open, setOpen] = useState(false);
-  const [selected, setSelected] = useState({ africa: false, americas: false, asia: false, europe: false, oceania: false, polar: false})
   
   // open and close the drop-down
   const handleOpen = () => {
@@ -17,10 +16,7 @@ export default function Filter(props) {
 
   // toggle if region filter is selected
   const handleSelect = (e) => {
-    const selectedCopy = { ...selected };
     const region = e.target.tagName === "P" ? e.target.parentNode.id : e.target.id;
-    selectedCopy[region] = !selected[region];
-    setSelected(selectedCopy)
     dispatch(updateFilter(region))
   }
 
@@ -33,27 +29,27 @@ export default function Filter(props) {
       <ul className={`dropList dmElement corners ${open && 'open'}`} id="dropList">
         <li className="dropItem" id="africa" key="africa" onClick={handleSelect}>
           <p>Africa</p>
-          {selected.africa ? <BiCheck /> : null}
+          {filters.africa ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="americas" key="americas" onClick={handleSelect}>
           <p>Americas</p>
-          {selected.americas ? <BiCheck /> : null}
+          {filters.americas ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="asia" key="asia"onClick={handleSelect} >
           <p>Asia</p>
-          {selected.asia ? <BiCheck /> : null}
+          {filters.asia ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="europe" key="europe" onClick={handleSelect} >
           <p>Europe</p>
-          {selected.europe ? <BiCheck /> : null}
+          {filters.europe ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="oceania" key="oceania" onClick={handleSelect} >
           <p>Oceania</p>
-          {selected.oceania ? <BiCheck /> : null}
+          {filters.oceania ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="polar" key="polar" onClick={handleSelect} >
           <p>Polar</p>
-          {selected.polar ? <BiCheck /> : null}
+          {filters.polar ? <BiCheck /> : null}
         </li>
       </ul>
     </div>

--- a/src/Components/ResetFilters/ResetFilters.css
+++ b/src/Components/ResetFilters/ResetFilters.css
@@ -1,0 +1,3 @@
+#resetBtn {
+  width: fit-content;
+}

--- a/src/Components/ResetFilters/ResetFilters.js
+++ b/src/Components/ResetFilters/ResetFilters.js
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from "react";
+import "./ResetFilters.css";
+
+import { useSelector, useDispatch } from 'react-redux'
+import { updateFilter } from '../../features/filtersSlice';
+import { updateSearch } from '../../features/searchSlice';
+import { updateSorting } from '../../features/sortingSlice';
+import { getElementError } from "@testing-library/react";
+
+
+function ResetFilters() {
+  const dispatch = useDispatch();
+  const filters = useSelector(state => state.filters);
+  const handleClick = () => {
+    dispatch(updateSearch(""))
+    dispatch(updateSorting("alphabetical"))
+    for (const country in filters) {
+      if (filters[country]) {
+        dispatch(updateFilter(country))
+        
+      }
+    }    
+    document.getElementById('searchInput').value = '';
+  }
+
+  return (
+    <div className="filter dropBtn dmElement corners" onClick={handleClick} id="resetBtn">
+      <p>Reset</p>
+    </div>
+  );
+}
+
+export default ResetFilters;

--- a/src/Components/SearchFilterWrapper/SearchFilterWrapper.js
+++ b/src/Components/SearchFilterWrapper/SearchFilterWrapper.js
@@ -3,6 +3,8 @@ import "./SearchFilterWrapper.css";
 import Filter from "../Filter/Filter";
 import Sorting from "../Sorting/Sorting";
 import SearchBar from "../Searchbar/SearchBar";
+import ResetFilters from "../ResetFilters/ResetFilters";
+
 
 export default function Search_Filter_wrapper(props) {
   return (
@@ -11,6 +13,7 @@ export default function Search_Filter_wrapper(props) {
       <div className="dropDowns">
         <Sorting />
         <Filter />
+        <ResetFilters />
       </div>
     </div>
   );

--- a/src/Components/Searchbar/SearchBar.js
+++ b/src/Components/Searchbar/SearchBar.js
@@ -9,12 +9,11 @@ import debounce from 'lodash.debounce';
 
 export default function SearchBar()    {
   const dispatch = useDispatch()
-  const [search, setSearch] = useState('')
+  const search = useSelector(state => state.search)
 
   const handleChange = (e) => {
     const searchInput = removeAccents(e.target.value)
-    // setSearch(searchInput);
-    dispatch(updateSearch(searchInput))
+    dispatch(updateSearch(searchInput.toLowerCase()))
   }
   
   // delay updating state if user still typing (half second delay)
@@ -24,7 +23,13 @@ export default function SearchBar()    {
     <div className="searchBar">
       <div id="searchBox" className="dmElement corners">
         <div id="searchIcon">< FaSearch/></div>
-        <input id="searchInput" className="dmElement corners" name="search-query" type="text" placeholder="Search for a country..." onChange={debounceChange} />
+        <input 
+          id="searchInput" 
+          className="dmElement corners" 
+          name="search-query" 
+          type="text" 
+          placeholder="Search for a country..." 
+          onChange={debounceChange} />
       </div>    
     </div>
     )

--- a/src/Components/Sorting/Sorting.js
+++ b/src/Components/Sorting/Sorting.js
@@ -9,7 +9,7 @@ export default function Sorting(props) {
 
   const dispatch = useDispatch()
   const [open, setOpen] = useState(false);
-  const [sorting, setSorting] = useState('alphabetical')
+  const sorting = useSelector(state => state.sorting);
   
   // open and close the drop-down
   const handleOpen = () => {
@@ -19,7 +19,6 @@ export default function Sorting(props) {
   // toggle if region filter is selected
   const handleSelect = (e) => {
     const sorting = e.target.tagName === "P" ? e.target.parentNode.id : e.target.id;
-    setSorting(sorting)
     dispatch(updateSorting(sorting))
   }
 
@@ -32,15 +31,15 @@ export default function Sorting(props) {
       <ul className={`dropList dmElement corners ${open && 'open'}`} id="dropList">
         <li className="dropItem" id="alphabetical" key=" alphabetical" onClick={handleSelect}>
           <p>Albabetical</p>
-          {sorting === 'alphabetical' ? <BiCheck /> : null}
+          {sorting.value === 'alphabetical' ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="population" key="population" onClick={handleSelect}>
           <p>Population</p>
-          {sorting === 'population' ? <BiCheck /> : null}
+          {sorting.value === 'population' ? <BiCheck /> : null}
         </li>
         <li className="dropItem" id="area" key="area" onClick={handleSelect} >
           <p>Area</p>
-          {sorting === 'area' ? <BiCheck /> : null}
+          {sorting.value === 'area' ? <BiCheck /> : null}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Added reset button with following functionality
- clear search bar
- set sorting to alphabetical
- remove region filters

Also in the changes I removed any local state for the search/sort/filter as it was causing an issue. Not everything is solely dependent on the redux state for this. This helped remove a few bugs. 

I am going to make a new issue to fix the css. It's a bit messy at the moment and the responsiveness of the bar needs looking at. The search bar shrinks but the drop downs don't (but should!). 